### PR TITLE
Replace bosh-template openstruct() method

### DIFF
--- a/lib/ostruct_config_store.rb
+++ b/lib/ostruct_config_store.rb
@@ -1,0 +1,50 @@
+require 'ostruct'
+
+# OpenStructConfigStore behaves like open struct except for if it can't find
+# a value in itself, it will ask the config_store.
+class OpenStructConfigStore < OpenStruct
+  # KvFinder recursively uses itself and the config_store to get values out
+  # of the config_store that are evaluated like so: kvfinder1.kvfinder2 and so on.
+  class KvFinder
+    def initialize(key, config_store)
+      @key = key
+      @config_store = config_store
+    end
+
+    def method_missing(name, *args)
+      @key << name.to_s
+      val = @config_store.get(@key.join('.'))
+      return val unless val.nil?
+
+      self
+    end
+  end
+
+  @@key = []
+
+  def initialize(hash = nil, config_store: nil)
+    @config_store = config_store
+    super(hash)
+  end
+
+  def method_missing(name, *args)
+    @@key.push(name.to_s)
+
+    val = super(name, *args)
+    unless val.nil?
+      @@key = [] unless val.instance_of?(OpenStructConfigStore)
+      return val
+    end
+
+    val = @config_store.get(@@key.join('.'))
+    return val unless val.nil?
+
+    finder = KvFinder.new(@@key.dup, @config_store)
+    @@key = []
+    finder
+  end
+
+  def new_ostruct_member(name)
+    name.to_sym
+  end
+end

--- a/spec/lib/evaluation_context_spec.rb
+++ b/spec/lib/evaluation_context_spec.rb
@@ -21,4 +21,61 @@ describe EvaluationContext do
     prop = context.p('fake.othervalue')
     expect(prop).to eq(expect_value)
   end
+
+
+  it 'should look up values that exist in properties' do
+    properties = { 'properties' => { 'fake' => { 'value' => 5 } } }
+    context = EvaluationContext.new(properties, nil)
+    prop = context.properties.fake.value
+    expect(prop).to eq(5)
+  end
+
+  it 'should look up values in consul that don''t exist in properties' do
+    properties = { 'properties' => { 'fake' => { 'value' => 5 } } }
+    config_store = double('config_store')
+    expect_value = 5
+
+    keys = %w(cc configuration)
+    keys.inject('') do |key, next_key|
+      next_key = key.length == 0 ? next_key : "#{key}.#{next_key}"
+      expect(config_store).to receive(:get)
+        .with(next_key)
+        .and_return(nil)
+        .ordered
+      next_key
+    end
+
+    expect(config_store).to receive(:get)
+      .with('cc.configuration.port')
+      .and_return(expect_value)
+      .ordered
+
+    context = EvaluationContext.new(properties, config_store)
+    prop = context.properties.cc.configuration.port
+    expect(prop).to eq(expect_value)
+  end
+
+  it 'should look up values in consul that half exist in properties' do
+    old_value = 20
+    expect_value = 5
+    properties = { 'properties' => { 'cc' => { 'port' => old_value } } }
+    config_store = double('config_store')
+
+    expect(config_store).to receive(:get)
+      .with('cc.configuration')
+      .and_return(nil)
+      .ordered
+    expect(config_store).to receive(:get)
+      .with('cc.configuration.port')
+      .and_return(expect_value)
+      .ordered
+
+    context = EvaluationContext.new(properties, config_store)
+
+    prop = context.properties.cc.configuration.port
+    expect(prop).to eq(expect_value)
+
+    prop = context.properties.cc.port
+    expect(prop).to eq(old_value)
+  end
 end


### PR DESCRIPTION
- Create a new object that replaces openstruct that can fallback to
  consul lookups
