### PR TITLE
HCF-330: Add --release parameter for resolving keys in the spec store.

### DIFF
--- a/bin/configgin
+++ b/bin/configgin
@@ -28,7 +28,7 @@ rescue ArgMissingError => e
   exit(1)
 end
 
-config_store = ConsulConfigStore.new(options[:consul], options[:prefix], options[:job], options[:role])
+config_store = ConsulConfigStore.new(options[:consul], options[:prefix], options[:release], options[:job], options[:role])
 
 Generate.generate(output: options[:output], input: options[:input], data: options[:data]) do |output, input|
   Generate.render(output, input, options[:template], config_store)

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -16,7 +16,7 @@ module Cli
       fail ArgMissingError, 'input or data'
     end
 
-    [:template, :consul, :prefix, :job, :role].each do |key|
+    [:template, :consul, :prefix, :release, :job, :role].each do |key|
       if options[key].nil? || options[key].empty?
         fail ArgMissingError, key.to_s
       end
@@ -45,6 +45,9 @@ module Cli
       end
       opts.on('-p', '--prefix name', 'Consul config key prefix') do |p|
         options[:prefix] = p
+      end
+      opts.on('--release name', 'CF release name') do |r|
+        options[:release] = r
       end
       opts.on('-j', '--job name', 'Job name') do |j|
         options[:job] = j

--- a/lib/consul_config_store.rb
+++ b/lib/consul_config_store.rb
@@ -7,10 +7,12 @@ class ConsulConfigStore
   #
   # @param consul_address [String] The address to the consul agent/server
   # @param prefix         [String] The prefix of the key sets.
+  # @param release        [String] The BOSH release (cf, diego, etc.)
   # @param job            [String] Job name
   # @param role           [String] Role name
-  def initialize(consul_address, prefix, job, role)
+  def initialize(consul_address, prefix, release, job, role)
     @prefix = prefix
+    @release = release
     @job = job
     @role = role
 
@@ -24,7 +26,7 @@ class ConsulConfigStore
   # @return       [Hash]   The giant hash from consul
   def build()
     lookup_order = %W(
-      /#{@prefix}/spec/#{@job}/
+      /#{@prefix}/spec/#{@release}/#{@job}/
       /#{@prefix}/opinions/
       /#{@prefix}/user/
       /#{@prefix}/role/#{@role}/

--- a/spec/cli/cli_spec.rb
+++ b/spec/cli/cli_spec.rb
@@ -16,7 +16,7 @@ describe Cli do
 
   context 'with a full config' do
     let(:config) {
-      { consul: 'consul', data: 'data', template: 'template', job: 'job', role: 'role', prefix: 'prefix' }
+      { consul: 'consul', data: 'data', template: 'template', release: 'release', job: 'job', role: 'role', prefix: 'prefix' }
     }
 
     it 'should accept correct arrangements of arguments' do
@@ -52,6 +52,13 @@ describe Cli do
       expect {
         Cli.check_opts(config)
       }.to raise_error(ArgMissingError, 'prefix')
+    end
+
+    it 'should fail if release is missing' do
+      config.delete(:release)
+      expect {
+        Cli.check_opts(config)
+      }.to raise_error(ArgMissingError, 'release')
     end
 
     it 'should fail if job is missing' do

--- a/spec/lib/consul_config_store_spec.rb
+++ b/spec/lib/consul_config_store_spec.rb
@@ -8,19 +8,20 @@ describe ConsulConfigStore do
 
       @address = 'address'
       @prefix = 'prefix'
+      @release = 'release'
       @job = 'cloud_controller_ng'
       @role = 'cc_role'
-      @config_store = ConsulConfigStore.new(@address, @prefix, @job, @role)
+      @config_store = ConsulConfigStore.new(@address, @prefix, @release, @job, @role)
     end
 
     it 'should ignore hashes that have no key found' do
       expect(Diplomat::Kv).to receive(:get)
-        .with('/prefix/spec/cloud_controller_ng/', { recurse: true })
+        .with('/prefix/spec/release/cloud_controller_ng/', { recurse: true })
         .and_return([
-          { key: 'prefix/spec/cloud_controller_ng/cc/k1', value: '1' },
-          { key: 'prefix/spec/cloud_controller_ng/cc/k2', value: '1' },
-          { key: 'prefix/spec/cloud_controller_ng/cc/k3', value: '1' },
-          { key: 'prefix/spec/cloud_controller_ng/cc/k4', value: '1' },
+          { key: 'prefix/spec/release/cloud_controller_ng/cc/k1', value: '1' },
+          { key: 'prefix/spec/release/cloud_controller_ng/cc/k2', value: '1' },
+          { key: 'prefix/spec/release/cloud_controller_ng/cc/k3', value: '1' },
+          { key: 'prefix/spec/release/cloud_controller_ng/cc/k4', value: '1' },
          ])
         .ordered
       expect(Diplomat::Kv).to receive(:get)
@@ -45,12 +46,12 @@ describe ConsulConfigStore do
 
     it 'should create an overridden set of hashes, getting the final value correct' do
       expect(Diplomat::Kv).to receive(:get)
-        .with('/prefix/spec/cloud_controller_ng/', { recurse: true })
+        .with('/prefix/spec/release/cloud_controller_ng/', { recurse: true })
         .and_return([
-          { key: 'prefix/spec/cloud_controller_ng/cc/k1', value: '1' },
-          { key: 'prefix/spec/cloud_controller_ng/cc/k2', value: '1' },
-          { key: 'prefix/spec/cloud_controller_ng/cc/k3', value: '1' },
-          { key: 'prefix/spec/cloud_controller_ng/cc/k4', value: '1' },
+          { key: 'prefix/spec/release/cloud_controller_ng/cc/k1', value: '1' },
+          { key: 'prefix/spec/release/cloud_controller_ng/cc/k2', value: '1' },
+          { key: 'prefix/spec/release/cloud_controller_ng/cc/k3', value: '1' },
+          { key: 'prefix/spec/release/cloud_controller_ng/cc/k4', value: '1' },
          ])
         .ordered
       expect(Diplomat::Kv).to receive(:get)
@@ -84,7 +85,7 @@ describe ConsulConfigStore do
     end
 
     it 'should fetch collections of hashes' do
-      prefix = '/hcf/spec/cloud_controller_ng'
+      prefix = '/hcf/spec/release/cloud_controller_ng'
       expect(Diplomat::Kv).to receive(:get)
         .with(prefix, { recurse: true })
         .and_return([
@@ -99,7 +100,7 @@ describe ConsulConfigStore do
     end
 
     it 'should yaml decode when fetching' do
-      prefix = '/hcf/spec/cloud_controller_ng'
+      prefix = '/hcf/spec/release/cloud_controller_ng'
       expect(Diplomat::Kv).to receive(:get)
         .with(prefix, { recurse: true })
         .and_return([


### PR DESCRIPTION
Pretty sure this requires matching changes in `fissile` to not break things horribly.  So it probably shouldn't be merged until that's coordinated.
