### PR TITLE
makefile: Actually supply environment variables to package.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,4 @@ lint:
 	bundle exec rubocop --fail-level=error
 
 dist:
-	./package.sh BRANCH=$(BRANCH) BUILD=$(BUILD) APP_VERSION=$(APP_VERSION)
+	/usr/bin/env BRANCH=$(BRANCH) BUILD=$(BUILD) APP_VERSION=$(APP_VERSION) ./package.sh


### PR DESCRIPTION
Unlike make and (the typical) configure, things given as arguments do not
automatically get exported as environment variables.  Call package.sh with
`env` instead to make sure it happens.
