### PR TITLE
Bump version to 0.18.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    configgin (0.18.2)
+    configgin (0.18.3)
       bosh-template (~> 2.0)
       deep_merge (~> 1.1)
       kubeclient (~> 2.0)

--- a/lib/configgin/version.rb
+++ b/lib/configgin/version.rb
@@ -1,3 +1,3 @@
 class Configgin
-  VERSION = '0.18.2'.freeze
+  VERSION = '0.18.3'.freeze
 end


### PR DESCRIPTION
Hi @mook-as ,

I just bumped version to `0.18.3` as you suggested [here](https://github.com/cloudfoundry-incubator/configgin/issues/90#issuecomment-435104548)to pick the new commit. Thanks!
