### PR TITLE
Use the new `service_name` field for job providers

### DIFF
--- a/lib/configgin/version.rb
+++ b/lib/configgin/version.rb
@@ -1,3 +1,3 @@
 class Configgin
-  VERSION = '0.18.3'.freeze
+  VERSION = '0.18.4'.freeze
 end

--- a/lib/kube_link_generator.rb
+++ b/lib/kube_link_generator.rb
@@ -172,9 +172,10 @@ class KubeLinkSpecs
 
     # Underscores aren't valid hostnames, so jobs are transformed in fissile to use dashes
     job_name = provider['job'].gsub('_', '-')
+    service_name = provider['service_name'] || "#{provider['role']}-#{job_name}"
 
     @links[key] = {
-      'address' => "#{provider['role']}-#{job_name}.#{ENV['KUBERNETES_NAMESPACE']}.svc.#{ENV['KUBERNETES_CLUSTER_DOMAIN']}",
+      'address' => "#{service_name}.#{ENV['KUBERNETES_NAMESPACE']}.svc.#{ENV['KUBERNETES_CLUSTER_DOMAIN']}",
       'instance_group' => '', # This is probably the role name from the manifest
       'default_network' => '',
       'deployment_name' => namespace,

--- a/update-stemcell.sh
+++ b/update-stemcell.sh
@@ -11,9 +11,10 @@
 
 set -o errexit -o nounset
 
-REPO="${REPO:-scf}"
+REPO="${REPO:-../../github.com/SUSE/scf}"
 
-IMAGE="$( cd "../${REPO}" && source .envrc && echo "${FISSILE_STEMCELL}" )"
+REPO="$( cd "${REPO}" && echo "${PWD}" )"
+IMAGE="$( cd "${REPO}" && source .envrc && echo "${FISSILE_STEMCELL}" )"
 
 name="${IMAGE%%:*}"
 tag="${IMAGE##*:}"
@@ -39,7 +40,7 @@ kubectl config use-context vagrant
 
 vagrant_ready=""
 if test -z "${NO_RUN:-}" ; then
-    if ( cd "$(dirname "$0")/../${REPO}" && (vagrant status 2>/dev/null | grep --quiet running) ) ; then
+    if ( cd "${REPO}" && (vagrant status 2>/dev/null | grep --quiet running) ) ; then
         vagrant_ready="true"
         releases=$(helm list --short)
         if test -n "${releases}" ; then
@@ -84,7 +85,7 @@ docker push "${docker_user}/${name##*/}:${tag}"
 
 test -n "${vagrant_ready}" || exit
 
-cd "$(dirname "$0")/../${REPO}"
+cd "${REPO}"
 
 vagrant ssh -- -tt <<EOF
     set -o errexit -o nounset


### PR DESCRIPTION
This requires https://github.com/cloudfoundry-incubator/fissile/pull/442

This makes the BOSH Links implementation support the custom service names.