### PR TITLE
Restart pods on changing imported BOSH properties

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -13,6 +13,7 @@ module Cli
         raise ArgMissingError, key.to_s
       end
     end
+    options[:bosh_deployment_manifest] ||= nil
   end
 
   # Make an option parser bound to the hash passed in.

--- a/lib/configgin.rb
+++ b/lib/configgin.rb
@@ -14,10 +14,10 @@ class Configgin
   # SVC_ACC_PATH is the location of the service account secrets
   SVC_ACC_PATH = '/var/run/secrets/kubernetes.io/serviceaccount'.freeze
 
-  def initialize(options)
-    @job_configs = JSON.parse(File.read(options[:jobs]))
-    @templates = YAML.load_file(options[:env2conf])
-    @bosh_deployment_manifest = options[:bosh_deployment_manifest]
+  def initialize(jobs:, env2conf:, bosh_deployment_manifest:)
+    @job_configs = JSON.parse(File.read(jobs))
+    @templates = YAML.load_file(env2conf)
+    @bosh_deployment_manifest = bosh_deployment_manifest
   end
 
   def run

--- a/lib/configgin.rb
+++ b/lib/configgin.rb
@@ -57,19 +57,21 @@ class Configgin
     jobs
   end
 
-  # Set the exported properties and their digests, and return the digests
+  # Set the exported properties and their digests, and return the digests.
   def patch_job_metadata(jobs)
     digests = {}
     jobs.each do |name, job|
       digest = property_digest(job.exported_properties)
       kube_client.patch_pod(
         @self_name,
-        { metadata: {
-          annotations: {
-            :"skiff-exported-properties-#{name}" => job.exported_properties.to_json,
-            :"skiff-exported-digest-#{name}" => digest
+        {
+          metadata: {
+            annotations: {
+              :"skiff-exported-properties-#{name}" => job.exported_properties.to_json,
+              :"skiff-exported-digest-#{name}" => digest
+            }
           }
-        } },
+        },
         kube_namespace
       )
       digests[name] = digest
@@ -87,7 +89,7 @@ class Configgin
     end
   end
 
-  # Some pods might have depended onthe properties exported by this pod; locate
+  # Some pods might have depended on the properties exported by this pod; locate
   # them and cause them to restart as appropriate.
   def restart_affected_pods(job_configs, job_digests)
     raise 'No digest' unless job_digests
@@ -121,7 +123,8 @@ class Configgin
           end
           # rubocop:enable Layout/RescueEnsureAlignment
           if response['reason'] == 'NotFound'
-            # The StatefulSet can be missing if we're configured to not have an optional instance group
+            # The StatefulSet can be missing if we're configured to not have an
+            # optional instance group.
             warn "Skipping patch of non-existant StatefulSet #{instance_group_name}"
             next
           end

--- a/lib/configgin.rb
+++ b/lib/configgin.rb
@@ -14,10 +14,11 @@ class Configgin
   # SVC_ACC_PATH is the location of the service account secrets
   SVC_ACC_PATH = '/var/run/secrets/kubernetes.io/serviceaccount'.freeze
 
-  def initialize(jobs:, env2conf:, bosh_deployment_manifest:)
+  def initialize(jobs:, env2conf:, bosh_deployment_manifest:, self_name: ENV['HOSTNAME'])
     @job_configs = JSON.parse(File.read(jobs))
     @templates = YAML.load_file(env2conf)
     @bosh_deployment_manifest = bosh_deployment_manifest
+    @self_name = self_name
   end
 
   def run
@@ -49,7 +50,8 @@ class Configgin
         spec: bosh_spec,
         namespace: kube_namespace,
         client: kube_client,
-        client_stateful_set: kube_client_stateful_set)
+        client_stateful_set: kube_client_stateful_set,
+        self_name: @self_name)
     end
     jobs
   end
@@ -60,7 +62,7 @@ class Configgin
     jobs.each do |name, job|
       digest = property_digest(job.exported_properties)
       kube_client.patch_pod(
-        ENV['HOSTNAME'],
+        @self_name,
         { metadata: {
           annotations: {
             :"skiff-exported-properties-#{name}" => job.exported_properties.to_json,
@@ -163,7 +165,7 @@ class Configgin
   end
 
   def instance_group
-    pod = kube_client.get_pod(ENV['HOSTNAME'], kube_namespace)
+    pod = kube_client.get_pod(@self_name, kube_namespace)
     pod['metadata']['labels']['app.kubernetes.io/component']
   end
 end

--- a/lib/job.rb
+++ b/lib/job.rb
@@ -4,10 +4,11 @@ require_relative 'kube_link_generator'
 
 # Job describes a single BOSH job
 class Job
-  def initialize(spec, namespace, client, client_stateful_set)
+  def initialize(spec:, namespace:, client:, client_stateful_set:, self_name: ENV['HOSTNAME'])
     @spec = spec
     @namespace = namespace
     @client = client
+    @self_name = self_name
     links = @spec['links'] = KubeLinkSpecs.new(@spec, @namespace, @client, client_stateful_set)
 
     # Figure out whether _this_ should bootstrap
@@ -36,7 +37,7 @@ class Job
   end
 
   def self_pod
-    @self_pod ||= @client.get_pod(ENV['HOSTNAME'], @namespace)
+    @self_pod ||= @client.get_pod(@self_name, @namespace)
   end
 
   def self_role

--- a/lib/job.rb
+++ b/lib/job.rb
@@ -20,7 +20,7 @@ class Job
   attr_reader :spec
 
   def exported_properties
-    @exported_properties ||= Hash.new.tap do |exported_properties|
+    @exported_properties ||= {}.tap do |exported_properties|
       spec['exported_properties'].each do |prop|
         src = spec['properties']
         dst = exported_properties
@@ -82,7 +82,7 @@ class Job
       out_file = nil
       raise "failed to open output file #{output_file_path}: #{e}"
     ensure
-      out_file.close unless out_file.nil?
+      out_file&.close
     end
   end
 end

--- a/lib/job.rb
+++ b/lib/job.rb
@@ -19,21 +19,20 @@ class Job
   attr_reader :spec
 
   def exported_properties
-    return @exported_propertes if @exported_properties
-    exported_properties = {}
-    spec['exported_properties'].each do |prop|
-      src = spec['properties']
-      dst = exported_properties
-      keys = prop.split('.')
-      leaf = keys.pop
-      keys.each do |key|
-        dst[key] ||= {}
-        dst = dst[key]
-        src = src.fetch(key, {})
+    @exported_properties ||= Hash.new.tap do |exported_properties|
+      spec['exported_properties'].each do |prop|
+        src = spec['properties']
+        dst = exported_properties
+        keys = prop.split('.')
+        leaf = keys.pop
+        keys.each do |key|
+          dst[key] ||= {}
+          dst = dst[key]
+          src = src.fetch(key, {})
+        end
+        dst[leaf] = src[leaf]
       end
-      dst[leaf] = src[leaf]
     end
-    @exported_properties = exported_properties
   end
 
   def self_pod

--- a/lib/kube_link_generator.rb
+++ b/lib/kube_link_generator.rb
@@ -2,7 +2,6 @@ require 'digest/sha1'
 require 'kubeclient'
 require 'uri'
 require_relative 'exceptions'
-require_relative 'property_digest'
 
 # KubeLinkSpecs provides the information required to generate BOSH links by
 # pretending to be a hash.

--- a/lib/kube_link_generator.rb
+++ b/lib/kube_link_generator.rb
@@ -72,7 +72,8 @@ class KubeLinkSpecs
   def get_exported_properties(role_name, pod, job_name)
     if pod.metadata.annotations["skiff-exported-properties-#{job_name}"]
       if pod.metadata.annotations["skiff-exported-digest-#{job_name}"]
-        # Copy the digest over, so that if the source role changes we can be restarted
+        # Copy the digest over, so that if the source role changes we can be
+        # restarted.
         digest = pod.metadata.annotations["skiff-exported-digest-#{job_name}"]
         client.patch_pod(
           ENV['HOSTNAME'],

--- a/lib/property_digest.rb
+++ b/lib/property_digest.rb
@@ -15,7 +15,5 @@ def property_digest(properties)
         end
     end
     json = normalize_object(properties).to_json
-    digest = Digest::SHA1.hexdigest(json)
-    STDERR.puts "Digesting #{properties.to_json} -> #{json} -> #{digest}"
-    digest
+    "sha1:#{Digest::SHA1.hexdigest(json)}"
 end

--- a/lib/property_digest.rb
+++ b/lib/property_digest.rb
@@ -1,0 +1,21 @@
+require 'digest/sha1'
+require 'json'
+
+# Given a properties (a JSON-serializable Hash), generate a digest that will be
+# consistent across runs even if the enumeration order of hashes changes.
+def property_digest(properties)
+    def normalize_object(obj)
+        case obj
+        when Hash
+            Hash.new.tap { |result| obj.sort.each { |k, v| result[k] = normalize_object(v) } }
+        when Enumerable
+            obj.map { |v| normalize_object(v) }
+        else
+            obj
+        end
+    end
+    json = normalize_object(properties).to_json
+    digest = Digest::SHA1.hexdigest(json)
+    STDERR.puts "Digesting #{properties.to_json} -> #{json} -> #{digest}"
+    digest
+end

--- a/lib/property_digest.rb
+++ b/lib/property_digest.rb
@@ -4,16 +4,15 @@ require 'json'
 # Given a properties (a JSON-serializable Hash), generate a digest that will be
 # consistent across runs even if the enumeration order of hashes changes.
 def property_digest(properties)
-    def normalize_object(obj)
-        case obj
-        when Hash
-            Hash.new.tap { |result| obj.sort.each { |k, v| result[k] = normalize_object(v) } }
-        when Enumerable
-            obj.map { |v| normalize_object(v) }
-        else
-            obj
-        end
+  normalize_object = lambda do |obj|
+    case obj
+    when Hash
+      {}.tap { |result| obj.sort.each { |k, v| result[k] = normalize_object.call(v) } }
+    when Enumerable
+      obj.map(&normalize_object)
+    else
+      obj
     end
-    json = normalize_object(properties).to_json
-    "sha1:#{Digest::SHA1.hexdigest(json)}"
+  end
+  "sha1:#{Digest::SHA1.hexdigest(normalize_object.call(properties).to_json)}"
 end

--- a/spec/lib/configgin_spec.rb
+++ b/spec/lib/configgin_spec.rb
@@ -5,7 +5,8 @@ describe Configgin do
   let(:options) {
     {
       jobs: fixture('nats-job-config.json'),
-      env2conf: fixture('nats-env2conf.yml')
+      env2conf: fixture('nats-env2conf.yml'),
+      bosh_deployment_manifest: nil,
     }
   }
   let(:client) {

--- a/spec/lib/configgin_spec.rb
+++ b/spec/lib/configgin_spec.rb
@@ -4,33 +4,42 @@ require 'configgin'
 describe Configgin do
   let(:options) {
     {
-      jobs: File.expand_path('fixtures/nats-job-config.json', __dir__),
-      env2conf: File.expand_path('fixtures/nats-env2conf.yml', __dir__)
+      jobs: fixture('nats-job-config.json'),
+      env2conf: fixture('nats-env2conf.yml')
     }
+  }
+  let(:client) {
+    MockKubeClient.new(fixture('state.yml'))
   }
   subject {
     described_class.new(options)
   }
 
   before(:each) {
-    allow(subject).to receive(:set_job_metadata)
     allow(subject).to receive(:render_job_templates)
     allow(subject).to receive(:kube_namespace).and_return('the-namespace')
     allow(subject).to receive(:kube_token).and_return('abcdefg')
+    allow(subject).to receive(:kube_client).and_return(client)
+    allow(subject).to receive(:instance_group).and_return('instance-group')
+    allow(subject).to receive(:restart_affected_pods) # and skip the call
     allow(File).to receive(:read).and_call_original
     allow(File).to receive(:read).with('/var/vcap/jobs-src/loggregator_agent/config_spec.json')
-      .and_return(File.read(File.expand_path('fixtures/nats-loggregator-config-spec.json', __dir__)))
+      .and_return(File.read(fixture('nats-loggregator-config-spec.json')))
   }
 
   describe '#run' do
     it 'reads the namespace' do
-      expect(Job).to receive(:new).with(anything, "the-namespace", any_args)
+      expect(Job).to receive(:new).and_wrap_original do |original, arguments|
+        expect(arguments[:namespace]).to eq('the-namespace')
+        original.call(arguments.merge(self_name: 'pod-0'))
+      end
       subject.run
     end
 
     it 'uses default values' do
-      expect(Job).to receive(:new) do |bosh_spec, *_|
-        expect(bosh_spec['properties']['loggregator']['tls']['agent']['cert']). to eq('')
+      expect(Job).to receive(:new).and_wrap_original do |original, arguments|
+        expect(arguments[:spec]['properties']['loggregator']['tls']['agent']['cert']).to eq('')
+        original.call(arguments.merge(self_name: 'pod-0'))
       end
       subject.run
     end
@@ -40,8 +49,9 @@ describe Configgin do
         stub_const('ENV', 'LOGGREGATOR_AGENT_CERT' => 'FOO')
       }
       it 'considers ENV variables in templates' do
-        expect(Job).to receive(:new) do |bosh_spec, *_|
-          expect(bosh_spec['properties']['loggregator']['tls']['agent']['cert']). to eq('FOO')
+        expect(Job).to receive(:new).and_wrap_original do |original, arguments|
+          expect(arguments[:spec]['properties']['loggregator']['tls']['agent']['cert']). to eq('FOO')
+          original.call(arguments.merge(self_name: 'pod-0'))
         end
 
         subject.run
@@ -55,8 +65,9 @@ describe Configgin do
 
       it 'considers values from the bosh manifest' do
         expect(subject).to receive(:instance_group).and_return('nats-server')
-        expect(Job).to receive(:new) do |bosh_spec, *_|
-          expect(bosh_spec['properties']['tls']['agent']['cert']). to eq('BAR')
+        expect(Job).to receive(:new).and_wrap_original do |original, arguments|
+          expect(arguments[:spec]['properties']['tls']['agent']['cert']). to eq('BAR')
+          original.call(arguments.merge(self_name: 'pod-0'))
         end
 
         subject.run

--- a/spec/lib/configgin_spec.rb
+++ b/spec/lib/configgin_spec.rb
@@ -26,7 +26,7 @@ describe Configgin do
     allow(subject).to receive(:instance_group).and_return('instance-group')
     allow(File).to receive(:read).and_call_original
     allow(File).to receive(:read).with('/var/vcap/jobs-src/loggregator_agent/config_spec.json')
-      .and_return(File.read(fixture('nats-loggregator-config-spec.json')))
+                                 .and_return(File.read(fixture('nats-loggregator-config-spec.json')))
   }
 
   describe '#run' do

--- a/spec/lib/environment_config_transmogrifier_spec.rb
+++ b/spec/lib/environment_config_transmogrifier_spec.rb
@@ -207,7 +207,7 @@ describe EnvironmentConfigTransmogrifier do
 
     it 'should ignore a secrets file' do
       # Arrange
-      allow(EnvironmentConfigTransmogrifier).to receive(:extendReplace) {}
+      allow(EnvironmentConfigTransmogrifier).to receive(:extend_replace) {}
       environment_templates = {}
 
       Dir.mktmpdir do |tmp|
@@ -220,20 +220,20 @@ describe EnvironmentConfigTransmogrifier do
         EnvironmentConfigTransmogrifier.transmogrify(@base_config, environment_templates,
                                                      secrets: secrets)
         # Asserts
-        expect(EnvironmentConfigTransmogrifier).to receive(:extendReplace).exactly(0).times
+        expect(EnvironmentConfigTransmogrifier).to receive(:extend_replace).exactly(0).times
       end
     end
 
     it 'should ignore a nil secrets' do
       # Arrange
-      allow(EnvironmentConfigTransmogrifier).to receive(:extendReplace) {}
+      allow(EnvironmentConfigTransmogrifier).to receive(:extend_replace) {}
       environment_templates = {}
 
       # Act
       EnvironmentConfigTransmogrifier.transmogrify(@base_config, environment_templates,
                                                    secrets: nil)
       # Asserts
-      expect(EnvironmentConfigTransmogrifier).to receive(:extendReplace).exactly(0).times
+      expect(EnvironmentConfigTransmogrifier).to receive(:extend_replace).exactly(0).times
     end
 
     it 'should recursively resolve subtitutions' do

--- a/spec/lib/fixtures/nats-loggregator-config-spec.json
+++ b/spec/lib/fixtures/nats-loggregator-config-spec.json
@@ -42,5 +42,14 @@
           "role": "doppler",
           "job": "doppler"
       }
+  },
+  "consumed_by": {
+      "nats-cli": [
+          {
+            "role": "debugger",
+            "job": "troubleshooter",
+            "service_name": "nats-nats_cli"
+          }
+      ]
   }
 }

--- a/spec/lib/fixtures/nats-loggregator-config-spec.json
+++ b/spec/lib/fixtures/nats-loggregator-config-spec.json
@@ -44,7 +44,7 @@
       }
   },
   "consumed_by": {
-      "nats-cli": [
+      "loggregator_agent": [
           {
             "role": "debugger",
             "job": "troubleshooter",

--- a/spec/lib/fixtures/state.yml
+++ b/spec/lib/fixtures/state.yml
@@ -3,7 +3,7 @@
 pod:
 - metadata:
     name: pod-0
-    namespace: namespace
+    namespace: the-namespace
     annotations:
       skiff-exported-properties-unused: '{}'
     labels:
@@ -17,7 +17,7 @@ pod:
     subdomain: provider-role
 - metadata:
     name: other-234z234
-    namespace: namespace
+    namespace: the-namespace
     annotations:
       skiff-exported-properties-provider-job: '{"hello":{"world":"ohai"}}'
     labels:
@@ -31,6 +31,6 @@ pod:
 service:
 - metadata:
     name: provider-role
-    namespace: namespace
+    namespace: the-namespace
   spec:
     clusterIP: '192.168.2.221'

--- a/spec/lib/fixtures/state.yml
+++ b/spec/lib/fixtures/state.yml
@@ -34,3 +34,8 @@ service:
     namespace: the-namespace
   spec:
     clusterIP: '192.168.2.221'
+
+stateful_set:
+- metadata:
+    name: debugger
+    namespace: the-namespace

--- a/spec/lib/job_spec.rb
+++ b/spec/lib/job_spec.rb
@@ -13,7 +13,7 @@ describe Job do
     expect_output = File.read(fixture('fake.yml'))
 
     let(:client) { MockKubeClient.new(fixture('state.yml')) }
-    subject(:job) { Job.new(bosh_spec, 'namespace', client, client) }
+    subject(:job) { Job.new(spec: bosh_spec, namespace: 'the-namespace', client: client, client_stateful_set: client, self_name: 'pod-0') }
 
     before do
       allow(ENV).to receive(:[]).and_wrap_original do |env, name|
@@ -98,34 +98,22 @@ describe Job do
     around(:each) { |ex| trap_error(ex) }
 
     it 'should bootstrap when pod is alone' do
-      allow(ENV).to receive(:[]).and_wrap_original do |env, name|
-        name == 'HOSTNAME' ? 'unrelated-pod-0' : env.call(name)
-      end
-      job = Job.new(bosh_spec, namespace, client, client)
+      job = Job.new(spec: bosh_spec, namespace: namespace, client: client, client_stateful_set: client, self_name: 'unrelated-pod-0')
       expect(job.spec['bootstrap']).to be_truthy
     end
 
     it 'should not break bootstrapping a pod in pending status' do
-      allow(ENV).to receive(:[]).and_wrap_original do |env, name|
-        name == 'HOSTNAME' ? 'pending-pod-0' : env.call(name)
-      end
-      job = Job.new(bosh_spec, namespace, client, client)
+      job = Job.new(spec: bosh_spec, namespace: namespace, client: client, client_stateful_set: client, self_name: 'pending-pod-0')
       expect(job.spec['containerStatuses']).to be_falsey
     end
 
     it 'should bootstrap when only pod with this image' do
-      allow(ENV).to receive(:[]).and_wrap_original do |env, name|
-        name == 'HOSTNAME' ? 'bootstrap-pod-3' : env.call(name)
-      end
-      job = Job.new(bosh_spec, namespace, client, client)
+      job = Job.new(spec: bosh_spec, namespace: namespace, client: client, client_stateful_set: client, self_name: 'bootstrap-pod-3')
       expect(job.spec['bootstrap']).to be_truthy
     end
 
     it 'shoud not upgrade when multiple pods with same image' do
-      allow(ENV).to receive(:[]).and_wrap_original do |env, name|
-        name == 'HOSTNAME' ? 'ready-pod-0' : env.call(name)
-      end
-      job = Job.new(bosh_spec, namespace, client, client)
+      job = Job.new(spec: bosh_spec, namespace: namespace, client: client, client_stateful_set: client, self_name: 'ready-pod-0')
       expect(job.spec['bootstrap']).to be_falsy
     end
   end

--- a/spec/lib/job_spec.rb
+++ b/spec/lib/job_spec.rb
@@ -42,9 +42,9 @@ describe Job do
           job.generate(restricted_file_duplicate, file.path, nil)
 
           # Assert
-          expect(format('%o', File.stat(file.path).mode)).to eq('100600')
+          expect(format('%<mode>o', mode: File.stat(file.path).mode)).to eq('100600')
         ensure
-          file.unlink unless file.nil?
+          file&.unlink
         end
       end
     end
@@ -61,7 +61,7 @@ describe Job do
         # Assert (compare with expect_filename)
         expect(File.read(file)).to eq(expect_output)
       ensure
-        file.unlink unless file.nil?
+        file&.unlink
       end
     end
 

--- a/spec/lib/kube_link_generator_spec.rb
+++ b/spec/lib/kube_link_generator_spec.rb
@@ -91,8 +91,9 @@ describe KubeLinkSpecs do
         answers = build_answers do |index, max, pods|
           if index + 1 < max
             pods.map! do |pod|
-              next pod if index % 2 == 0 && pod.metadata.name.start_with?('old')
-              next pod if index % 2 == 1 && pod.metadata.name.start_with?('new')
+              next pod if index.even? && pod.metadata.name.start_with?('old')
+              next pod if index.odd?  && pod.metadata.name.start_with?('new')
+
               # Drop the podIP
               status = OpenStruct.new(pod.status.to_h.merge(podIP: nil)).freeze
               OpenStruct.new(pod.to_h.merge(status: status)).freeze
@@ -113,6 +114,7 @@ describe KubeLinkSpecs do
         answers = build_answers do |_, _, pods|
           pods.map! do |pod|
             next pod if pod.metadata.name.start_with? 'old'
+
             # Drop the podIP
             status = OpenStruct.new(pod.status.to_h.merge(podIP: nil)).freeze
             OpenStruct.new(pod.to_h.merge(status: status)).freeze
@@ -130,6 +132,7 @@ describe KubeLinkSpecs do
         answers = build_answers do |_, _, pods|
           pods.map! do |pod|
             next pod if pod.metadata.name.start_with? 'new'
+
             # Drop the podIP
             status = OpenStruct.new(pod.status.to_h.merge(podIP: nil)).freeze
             OpenStruct.new(pod.to_h.merge(status: status)).freeze

--- a/spec/lib/kube_link_generator_spec.rb
+++ b/spec/lib/kube_link_generator_spec.rb
@@ -40,9 +40,9 @@ describe KubeLinkSpecs do
         pods = specs.get_pods_for_role('dummy', 'dummy')
         expect(pods.length).to be 2
         expect(pods[0].metadata.name).to eq('old-pod-0')
-        expect(specs.get_exported_properties(pods[0], 'dummy')).to include('prop' => 'a')
+        expect(specs.get_exported_properties('dummy-role', pods[0], 'dummy')).to include('prop' => 'a')
         expect(pods[1].metadata.name).to eq('new-pod-0')
-        expect(specs.get_exported_properties(pods[1], 'dummy')).to include('prop' => 'b')
+        expect(specs.get_exported_properties('dummy-role', pods[1], 'dummy')).to include('prop' => 'b')
       end
 
       # Build a client with the given answers (sequentially)
@@ -162,12 +162,13 @@ describe KubeLinkSpecs do
 
     context :get_pod_instance_info do
       it 'should return the expected information' do
+        role = 'dummy-role'
         job = 'dummy'
         pods = specs._get_pods_for_role(job)
         pod = pods.find { |p| p.metadata.name.start_with? 'bootstrap-pod' }
         expect(pod).to_not be_nil
         pods_per_image = specs.get_pods_per_image(pods)
-        expect(specs.get_pod_instance_info(pod, job, pods_per_image)).to include(
+        expect(specs.get_pod_instance_info(role, pod, job, pods_per_image)).to include(
           'address'    => 'bootstrap-pod-3.provider-role.namespace.svc.domain',
           'az'         => 'az0',
           'bootstrap'  => true,
@@ -178,12 +179,13 @@ describe KubeLinkSpecs do
         )
       end
       it 'should not be bootstrap with multiple pods of the same images' do
+        role = 'dummy-role'
         job = 'dummy'
         pods = specs._get_pods_for_role(job)
         pod = pods.find { |p| p.metadata.name.start_with? 'ready-pod-0' }
         expect(pod).to_not be_nil
         pods_per_image = specs.get_pods_per_image(pods)
-        instance_info = specs.get_pod_instance_info(pod, job, pods_per_image)
+        instance_info = specs.get_pod_instance_info(role, pod, job, pods_per_image)
         expect(instance_info['bootstrap']).not_to be_truthy
       end
     end

--- a/spec/lib/property_digest_spec.rb
+++ b/spec/lib/property_digest_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'property_digest'
+
+describe :property_digest do
+    def compare_digest(object, json)
+        expect(property_digest(object)).to eq "sha1:#{Digest::SHA1.hexdigest(json)}"
+    end
+    it 'should digest a number' do
+        compare_digest 1, '1'
+    end
+    it 'should digest a string' do
+        compare_digest 'foo', '"foo"'
+    end
+    it 'should digest an array' do
+        compare_digest %w(foo bar), '["foo","bar"]'
+    end
+    it 'should digest a hash' do
+        compare_digest ({a: 1, b: 2}), '{"a":1,"b":2}'
+    end
+    it 'should sort a hash before digesting' do
+        compare_digest ({b: 1, a: 2}), '{"a":2,"b":1}'
+    end
+    it 'should sort hashes nested in arrays' do
+        compare_digest [b: 1, a: 2], '[{"a":2,"b":1}]'
+    end
+    it 'should sort hashes nested in hashes' do
+        compare_digest ({c: {b: 1, a: 2}}), '{"c":{"a":2,"b":1}}'
+    end
+end

--- a/spec/lib/property_digest_spec.rb
+++ b/spec/lib/property_digest_spec.rb
@@ -2,28 +2,28 @@ require 'spec_helper'
 require 'property_digest'
 
 describe :property_digest do
-    def compare_digest(object, json)
-        expect(property_digest(object)).to eq "sha1:#{Digest::SHA1.hexdigest(json)}"
-    end
-    it 'should digest a number' do
-        compare_digest 1, '1'
-    end
-    it 'should digest a string' do
-        compare_digest 'foo', '"foo"'
-    end
-    it 'should digest an array' do
-        compare_digest %w(foo bar), '["foo","bar"]'
-    end
-    it 'should digest a hash' do
-        compare_digest ({a: 1, b: 2}), '{"a":1,"b":2}'
-    end
-    it 'should sort a hash before digesting' do
-        compare_digest ({b: 1, a: 2}), '{"a":2,"b":1}'
-    end
-    it 'should sort hashes nested in arrays' do
-        compare_digest [b: 1, a: 2], '[{"a":2,"b":1}]'
-    end
-    it 'should sort hashes nested in hashes' do
-        compare_digest ({c: {b: 1, a: 2}}), '{"c":{"a":2,"b":1}}'
-    end
+  def compare_digest(object, json)
+    expect(property_digest(object)).to eq "sha1:#{Digest::SHA1.hexdigest(json)}"
+  end
+  it 'should digest a number' do
+    compare_digest 1, '1'
+  end
+  it 'should digest a string' do
+    compare_digest 'foo', '"foo"'
+  end
+  it 'should digest an array' do
+    compare_digest %w[foo bar], '["foo","bar"]'
+  end
+  it 'should digest a hash' do
+    compare_digest ({ a: 1, b: 2 }), '{"a":1,"b":2}'
+  end
+  it 'should sort a hash before digesting' do
+    compare_digest ({ b: 1, a: 2 }), '{"a":2,"b":1}'
+  end
+  it 'should sort hashes nested in arrays' do
+    compare_digest [b: 1, a: 2], '[{"a":2,"b":1}]'
+  end
+  it 'should sort hashes nested in hashes' do
+    compare_digest ({ c: { b: 1, a: 2 } }), '{"c":{"a":2,"b":1}}'
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,26 +48,26 @@ class MockKubeClient
   end
 
   def respond_to_missing?(method_name, include_private = false)
-    return true if method_name.to_s.start_with? 'get_'
+    return true if /^(?:get|patch)_/ =~ method_name.to_s
 
     super
   end
 
-  # _convert_ostruct takes an object and recursively converts any
-  # encountered hashes to an ostruct
-  def _convert_ostruct(obj)
-    case obj
-    when Hash, OpenStruct
-      OpenStruct.new(Hash[obj.map { |k, v| [k, _convert_ostruct(v)] }])
-    when Array
-      obj.map { |v| _convert_ostruct(v) }
-    else
-      obj
-    end
-  end
-
   def initialize(file_name)
-    @state = _convert_ostruct(YAML.load_file(file_name))
+    @state = convert_to_openstruct(YAML.load_file(file_name))
+  end
+end
+
+# convert_to_openstruct takes an object and recursively converts any
+# encountered hashes to an OpenStruct
+def convert_to_openstruct(obj)
+  case obj
+  when Hash, OpenStruct
+    OpenStruct.new(Hash[obj.map { |k, v| [k, convert_to_openstruct(v)] }])
+  when Array
+    obj.map { |v| convert_to_openstruct(v) }
+  else
+    obj
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,9 @@ class MockKubeClient
   def initialize(file_name)
     @state = _convert_ostruct(YAML.load_file(file_name))
   end
+
+  def patch_pod(name, patch, namespace)
+  end
 end
 
 def trap_error(example)


### PR DESCRIPTION
This implements pods (on changing their exported properties) restarting pod which are known to have a dependency on the changed properties.

https://github.com/cloudfoundry-incubator/fissile/pull/470 implements tracking this dependency information in the images generated by fissile; this PR makes configgin read those changes and sets the digests on the statefulsets which import those properties.  This also makes configgin set the properties on import time, such that if we hit a race where a pod manages to import the properties before the exporting pod changes the statefulset we will not be restarted.

This also includes a changeset to silence much of the rubocop lint warnings (excluding the metrics categories that will require refactoring).