### PR TITLE
Configgin#expected_annotations: support job configs w/o consumer info

### DIFF
--- a/lib/configgin.rb
+++ b/lib/configgin.rb
@@ -128,7 +128,7 @@ class Configgin
     instance_groups_to_examine = Hash.new { |h, k| h[k] = {} }
     job_configs.values.each do |job_config|
       base_config = JSON.parse(File.read(job_config['base']))
-      base_config['consumed_by'].each_pair do |provider_name, consumer_jobs|
+      base_config.fetch('consumed_by', {}).each_pair do |provider_name, consumer_jobs|
         consumer_jobs.each do |consumer_job|
           digest_key = "skiff-imported-properties-#{instance_group}-#{provider_name}"
           instance_groups_to_examine[consumer_job['role']][digest_key] = job_digests[provider_name]

--- a/spec/lib/configgin_spec.rb
+++ b/spec/lib/configgin_spec.rb
@@ -147,6 +147,15 @@ describe Configgin do
         }
       )
     end
+    it 'should do nothing with older job configs' do
+      patched_spec = JSON.parse(File.read(fixture('nats-loggregator-config-spec.json')))
+      patched_spec.delete 'consumed_by'
+      allow(File).to receive(:read).with('/var/vcap/jobs-src/loggregator_agent/config_spec.json')
+                                   .and_return(patched_spec.to_json)
+      expect do
+        subject.expected_annotations(job_configs, job_digests)
+      end.not_to raise_error
+    end
   end
 
   describe '#restart_affected_pods' do


### PR DESCRIPTION
This makes it so this works against older versions of fissile (where we do not have the consumed_by info); in that case we just skip trying to restart pods.