### PR TITLE
Restrict pod selection to those with images matching our statefulset

### DIFF
--- a/spec/lib/fixtures/state-jobless-properties.yml
+++ b/spec/lib/fixtures/state-jobless-properties.yml
@@ -11,6 +11,10 @@ pod:
       app.kubernetes.io/component: dummy
     annotations:
       skiff-exported-properties: '{"dummy": {"prop": "a"}}'
+  spec:
+    containers:
+    - image: docker.io/image-one
+    - image: docker.io/image-two
   status:
     podIP: 192.0.2.1
     containerStatuses:
@@ -23,6 +27,10 @@ pod:
       app.kubernetes.io/component: dummy
     annotations:
       skiff-exported-properties-dummy: '{"prop": "b"}'
+  spec:
+    containers:
+    - image: docker.io/image-one
+    - image: docker.io/image-two
   status:
     podIP: 192.0.2.2
     containerStatuses:

--- a/spec/lib/fixtures/state-multi.yml
+++ b/spec/lib/fixtures/state-multi.yml
@@ -11,6 +11,9 @@ pod:
       skiff-exported-properties-dummy: '{}'
   spec:
     subdomain: provider-role
+    containers:
+    - image: docker.io/image-one
+    - image: docker.io/image-two
   status:
     podIP: 1.2.3.4
     containerStatuses:
@@ -24,6 +27,10 @@ pod:
       app.kubernetes.io/component: dummy
     annotations:
       skiff-exported-properties-dummy: '{}'
+  spec:
+    containers:
+    - image: docker.io/image-one
+    - image: docker.io/image-two
   status:
     podIP: 1.2.3.4
     containerStatuses:
@@ -39,6 +46,9 @@ pod:
       skiff-exported-properties-dummy: '{}'
   spec:
     subdomain: provider-role
+    containers:
+    - image: docker.io/image-one
+    - image: docker.io/image-two
   status:
     podIP: 1.2.3.4
     containerStatuses:
@@ -51,6 +61,9 @@ pod:
       app.kubernetes.io/component: unrelated
     annotations:
       skiff-exported-properties-dummy: '{}'
+  spec:
+    containers:
+    - image: docker://ccc
   status:
     podIP: 1.2.3.4
     containerStatuses:
@@ -63,6 +76,9 @@ pod:
       app.kubernetes.io/component: pending
     annotations:
       skiff-exported-properties-dummy: '{}'
+  spec:
+    containers:
+    - image: docker://eee
   status:
     podIP: 1.2.3.4
     containerStatuses: ~ # Simulate pending pod

--- a/spec/lib/fixtures/state.yml
+++ b/spec/lib/fixtures/state.yml
@@ -15,6 +15,9 @@ pod:
     - imageID: docker://image-two
   spec:
     subdomain: provider-role
+    containers:
+    - image: docker.io/image-one
+    - image: docker.io/image-two
 - metadata:
     name: other-234z234
     namespace: the-namespace
@@ -22,6 +25,10 @@ pod:
       skiff-exported-properties-provider-job: '{"hello":{"world":"ohai"}}'
     labels:
       app.kubernetes.io/component: provider-role
+  spec:
+    containers:
+    - image: docker.io/image-one
+    - image: docker.io/image-two
   status:
     podIP: '192.168.2.39'
     containerStatuses:
@@ -39,3 +46,25 @@ stateful_set:
 - metadata:
     name: debugger
     namespace: the-namespace
+- metadata:
+    name: fake
+    namespace: the-namespace
+    labels:
+      app.kubernetes.io/component: fake
+  spec:
+    template:
+      spec:
+        containers:
+        - image: docker.io/image-one
+        - image: docker.io/image-two
+- metadata:
+    name: provider-role
+    namespace: the-namespace
+    labels:
+      app.kubernetes.io/component: provider-role
+  spec:
+    template:
+      spec:
+        containers:
+        - image: docker.io/image-one
+        - image: docker.io/image-two

--- a/spec/lib/fixtures/stateful-set.yml
+++ b/spec/lib/fixtures/stateful-set.yml
@@ -9,3 +9,8 @@ stateful_set:
     spec:
       replicas: 3
       serviceName: dummy-set
+      template:
+        spec:
+          containers:
+          - image: docker.io/image-one
+          - image: docker.io/image-two

--- a/spec/lib/kube_link_generator_spec.rb
+++ b/spec/lib/kube_link_generator_spec.rb
@@ -167,7 +167,8 @@ describe KubeLinkSpecs do
       it 'should return the expected information' do
         role = 'dummy-role'
         job = 'dummy'
-        pods = specs._get_pods_for_role(job)
+        sts = "docker.io/image-one\ndocker.io/image-two"
+        pods = specs._get_pods_for_role(job, sts)
         pod = pods.find { |p| p.metadata.name.start_with? 'bootstrap-pod' }
         expect(pod).to_not be_nil
         pods_per_image = specs.get_pods_per_image(pods)
@@ -184,7 +185,8 @@ describe KubeLinkSpecs do
       it 'should not be bootstrap with multiple pods of the same images' do
         role = 'dummy-role'
         job = 'dummy'
-        pods = specs._get_pods_for_role(job)
+        sts = "docker.io/image-one\ndocker.io/image-two"
+        pods = specs._get_pods_for_role(job, sts)
         pod = pods.find { |p| p.metadata.name.start_with? 'ready-pod-0' }
         expect(pod).to_not be_nil
         pods_per_image = specs.get_pods_per_image(pods)
@@ -196,7 +198,8 @@ describe KubeLinkSpecs do
     context :get_pods_per_image do
       it 'should return the expected counts' do
         job = 'dummy'
-        pods = specs._get_pods_for_role(job)
+        sts = "docker.io/image-one\ndocker.io/image-two"
+        pods = specs._get_pods_for_role(job, sts)
         pods_per_image = specs.get_pods_per_image(pods)
         expect(pods_per_image).to eq(
           '893dd4a8-2067-44d3-aae7-1389f6a1789a' => 2,

--- a/spec/lib/kube_link_generator_spec.rb
+++ b/spec/lib/kube_link_generator_spec.rb
@@ -167,8 +167,8 @@ describe KubeLinkSpecs do
       it 'should return the expected information' do
         role = 'dummy-role'
         job = 'dummy'
-        sts = "docker.io/image-one\ndocker.io/image-two"
-        pods = specs._get_pods_for_role(job, sts)
+        sts_image = "docker.io/image-one\ndocker.io/image-two"
+        pods = specs._get_pods_for_role(job, sts_image)
         pod = pods.find { |p| p.metadata.name.start_with? 'bootstrap-pod' }
         expect(pod).to_not be_nil
         pods_per_image = specs.get_pods_per_image(pods)
@@ -185,8 +185,8 @@ describe KubeLinkSpecs do
       it 'should not be bootstrap with multiple pods of the same images' do
         role = 'dummy-role'
         job = 'dummy'
-        sts = "docker.io/image-one\ndocker.io/image-two"
-        pods = specs._get_pods_for_role(job, sts)
+        sts_image = "docker.io/image-one\ndocker.io/image-two"
+        pods = specs._get_pods_for_role(job, sts_image)
         pod = pods.find { |p| p.metadata.name.start_with? 'ready-pod-0' }
         expect(pod).to_not be_nil
         pods_per_image = specs.get_pods_per_image(pods)
@@ -198,8 +198,8 @@ describe KubeLinkSpecs do
     context :get_pods_per_image do
       it 'should return the expected counts' do
         job = 'dummy'
-        sts = "docker.io/image-one\ndocker.io/image-two"
-        pods = specs._get_pods_for_role(job, sts)
+        sts_image = "docker.io/image-one\ndocker.io/image-two"
+        pods = specs._get_pods_for_role(job, sts_image)
         pods_per_image = specs.get_pods_per_image(pods)
         expect(pods_per_image).to eq(
           '893dd4a8-2067-44d3-aae7-1389f6a1789a' => 2,


### PR DESCRIPTION
Ref: https://trello.com/c/DAAtVnaR/1052-14rc2-2161-cap-ha-upgrade-doppler-1-not-coming-up

In the case of upgrades this prevents pods running the old image of the role to be considered as possible good jobs. Should prevent us from getting stuck waiting on all pods.
