### PR TITLE
Reduce the prefix used in the property for pod restart to have more space for role and job names.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    configgin (0.18.5)
+    configgin (0.18.6)
       bosh-template (~> 2.0)
       deep_merge (~> 1.1)
       kubeclient (~> 2.0)
@@ -113,7 +113,7 @@ GEM
     thor (0.20.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.5)
+    unf_ext (0.0.7.6)
     unicode-display_width (1.4.0)
 
 PLATFORMS

--- a/lib/configgin.rb
+++ b/lib/configgin.rb
@@ -130,7 +130,7 @@ class Configgin
       base_config = JSON.parse(File.read(job_config['base']))
       base_config.fetch('consumed_by', {}).each_pair do |provider_name, consumer_jobs|
         consumer_jobs.each do |consumer_job|
-          digest_key = "skiff-imported-properties-#{instance_group}-#{provider_name}"
+          digest_key = "skiff-in-props-#{instance_group}-#{provider_name}"
           instance_groups_to_examine[consumer_job['role']][digest_key] = job_digests[provider_name]
         end
       end

--- a/lib/kube_link_generator.rb
+++ b/lib/kube_link_generator.rb
@@ -90,7 +90,7 @@ class KubeLinkSpecs
         digest = pod.metadata.annotations["skiff-exported-digest-#{job_name}"]
         client.patch_pod(
           ENV['HOSTNAME'],
-          { metadata: { annotations: { :"skiff-imported-properties-#{role_name}-#{job_name}" => digest } } },
+          { metadata: { annotations: { :"skiff-in-props-#{role_name}-#{job_name}" => digest } } },
           namespace
         )
       end

--- a/spec/lib/configgin_spec.rb
+++ b/spec/lib/configgin_spec.rb
@@ -81,7 +81,7 @@ describe Configgin do
       expect(statefulset).not_to be_nil
 
       exported_key = 'skiff-exported-digest-loggregator_agent'
-      imported_key = 'skiff-imported-properties-instance-group-loggregator_agent'
+      imported_key = 'skiff-in-props-instance-group-loggregator_agent'
       expect(statefulset.spec.template.metadata.annotations[imported_key]).to eq pod.metadata.annotations[exported_key]
     end
   end
@@ -143,7 +143,7 @@ describe Configgin do
       result = subject.expected_annotations(job_configs, job_digests)
       expect(result).to eq(
         'debugger' => {
-          'skiff-imported-properties-instance-group-loggregator_agent' => '123'
+          'skiff-in-props-instance-group-loggregator_agent' => '123'
         }
       )
     end


### PR DESCRIPTION
Ref: https://trello.com/c/edcUo2BW/1063-autoscaler-broken-on-jenkins-too-long-a-name-for-a-property

The issue to be fixed seems to have come in with #97 .

Configgin is bumped to 0.18.7.
