### PR TITLE
Version bump to 0.18.7.

### DIFF
--- a/lib/configgin/version.rb
+++ b/lib/configgin/version.rb
@@ -1,3 +1,3 @@
 class Configgin
-  VERSION = '0.18.6'.freeze
+  VERSION = '0.18.7'.freeze
 end


### PR DESCRIPTION
Ref: https://trello.com/c/edcUo2BW/1063-autoscaler-broken-on-jenkins-too-long-a-name-for-a-property