### PR TITLE
Fix renamed provider for property exports

### DIFF
--- a/lib/configgin.rb
+++ b/lib/configgin.rb
@@ -126,12 +126,12 @@ class Configgin
   # each job imports.
   def expected_annotations(job_configs, job_digests)
     instance_groups_to_examine = Hash.new { |h, k| h[k] = {} }
-    job_configs.values.each do |job_config|
+    job_configs.each_pair do |job_name, job_config|
       base_config = JSON.parse(File.read(job_config['base']))
-      base_config.fetch('consumed_by', {}).each_pair do |provider_name, consumer_jobs|
+      base_config.fetch('consumed_by', {}).values.each do |consumer_jobs|
         consumer_jobs.each do |consumer_job|
-          digest_key = "skiff-in-props-#{instance_group}-#{provider_name}"
-          instance_groups_to_examine[consumer_job['role']][digest_key] = job_digests[provider_name]
+          digest_key = "skiff-in-props-#{instance_group}-#{job_name}"
+          instance_groups_to_examine[consumer_job['role']][digest_key] = job_digests[job_name]
         end
       end
     end

--- a/spec/lib/fixtures/nats-loggregator-config-spec.json
+++ b/spec/lib/fixtures/nats-loggregator-config-spec.json
@@ -44,7 +44,7 @@
       }
   },
   "consumed_by": {
-      "loggregator_agent": [
+      "renamed_provider": [
           {
             "role": "debugger",
             "job": "troubleshooter",


### PR DESCRIPTION
When a provider name does _not_ match the job name, make sure that we use the job name for looking up imported/exported properties.  Otherwise we end up not finding the property digest, and skip setting the imports correctly (which leads to us not restarting pods as desired).

Fixes jsc#CAP-594.