### PR TITLE
Version bump to 0.18.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    configgin (0.18.6)
+    configgin (0.18.8)
       bosh-template (~> 2.0)
       deep_merge (~> 1.1)
       kubeclient (~> 2.0)
@@ -14,7 +14,7 @@ GEM
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
-    bosh-template (2.2.0)
+    bosh-template (2.2.1)
       semi_semantic (~> 1.2.0)
     coderay (1.1.2)
     deep_merge (1.2.1)

--- a/lib/configgin/version.rb
+++ b/lib/configgin/version.rb
@@ -1,3 +1,3 @@
 class Configgin
-  VERSION = '0.18.7'.freeze
+  VERSION = '0.18.8'.freeze
 end


### PR DESCRIPTION
This pulls in fixes for BOSH link property imports.