### PR TITLE
Store exported properties in secrets instead of annotations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    configgin (0.18.8)
+    configgin (0.19.0)
       bosh-template (~> 2.0)
       deep_merge (~> 1.1)
       kubeclient (~> 2.0)

--- a/lib/configgin.rb
+++ b/lib/configgin.rb
@@ -71,12 +71,12 @@ class Configgin
     # Make sure the secret gets removed when the pod is deleted.
     secret.metadata.ownerReferences = [
       {
-        :apiVersion => pod.apiVersion,
-        :blockOwnerDeletion => false,
-        :controller => false,
-        :kind => pod.kind,
-        :name => pod.metadata.name,
-        :uid => pod.metadata.uid,
+        apiVersion: pod.apiVersion,
+        blockOwnerDeletion: false,
+        controller: false,
+        kind: pod.kind,
+        name: pod.metadata.name,
+        uid: pod.metadata.uid,
       }
     ]
 

--- a/lib/configgin/version.rb
+++ b/lib/configgin/version.rb
@@ -1,3 +1,3 @@
 class Configgin
-  VERSION = '0.18.8'.freeze
+  VERSION = '0.19.0'.freeze
 end

--- a/lib/kube_link_generator.rb
+++ b/lib/kube_link_generator.rb
@@ -69,10 +69,7 @@ class KubeLinkSpecs
               next true if secret.data["skiff-exported-properties-#{job}"]
 
             rescue
-              next true if pod.metadata.annotations["skiff-exported-properties-#{job}"]
-
-              # Fall back to non-job-specific properties, for upgrades from older versions
-              pod.metadata.annotations['skiff-exported-properties']
+              pod.metadata.annotations["skiff-exported-properties-#{job}"]
             end
           end
 
@@ -122,10 +119,6 @@ class KubeLinkSpecs
         patch_pod_with_imported_properties(role_name, job_name, digest)
       end
       JSON.parse(pod.metadata.annotations["skiff-exported-properties-#{job_name}"])
-
-    # Oldest implementation stored exported properties in a single annotation (hash of all jobs).
-    elsif pod.metadata.annotations['skiff-exported-properties']
-      JSON.parse(pod.metadata.annotations['skiff-exported-properties'])[job_name]
 
     else
       {}

--- a/spec/lib/fixtures/state-jobless-properties.yml
+++ b/spec/lib/fixtures/state-jobless-properties.yml
@@ -5,7 +5,7 @@
 pod:
 - metadata:
     uid: 5919ad5d-f09d-4a20-8a26-1081a3c0003e
-    name: old-pod-0
+    name: oldest-pod-0
     namespace: namespace
     labels:
       app.kubernetes.io/component: dummy
@@ -21,7 +21,7 @@ pod:
     - imageID: docker://aaa
 - metadata:
     uid: 225f47c4-cc85-41d4-ade7-4348b233335a
-    name: new-pod-0
+    name: old-pod-0
     namespace: namespace
     labels:
       app.kubernetes.io/component: dummy
@@ -35,3 +35,29 @@ pod:
     podIP: 192.0.2.2
     containerStatuses:
     - imageID: docker://bbb
+- metadata:
+    uid: 4123b33d-8e32-4d9c-baa5-c24704e830c3
+    name: new-pod-0
+    namespace: namespace
+    labels:
+      app.kubernetes.io/component: dummy
+    annotations: {}
+  spec:
+    containers:
+    - image: docker.io/image-one
+    - image: docker.io/image-two
+  status:
+    podIP: 192.0.2.2
+    containerStatuses:
+    - imageID: docker://bbb
+
+secret:
+- metadata:
+    name: new-pod-0-4123b33d-8e32-4d9c-baa5-c24704e830c3
+    namespace: namespace
+  data:
+    # echo '{"prop": "c"}' | base64
+    skiff-exported-properties-dummy: "eyJwcm9wIjogImMifQo="
+    # NOT the correct digest!
+    # echo sha1:adc83b19e793491b1c6ea0fd8b46cd9f32e592fc | base64
+    # skiff-exported-digest-dummy: "c2hhMTphZGM4M2IxOWU3OTM0OTFiMWM2ZWEwZmQ4YjQ2Y2Q5ZjMyZTU5MmZjCg=="

--- a/spec/lib/fixtures/state-jobless-properties.yml
+++ b/spec/lib/fixtures/state-jobless-properties.yml
@@ -4,22 +4,6 @@
 ---
 pod:
 - metadata:
-    uid: 5919ad5d-f09d-4a20-8a26-1081a3c0003e
-    name: oldest-pod-0
-    namespace: namespace
-    labels:
-      app.kubernetes.io/component: dummy
-    annotations:
-      skiff-exported-properties: '{"dummy": {"prop": "a"}}'
-  spec:
-    containers:
-    - image: docker.io/image-one
-    - image: docker.io/image-two
-  status:
-    podIP: 192.0.2.1
-    containerStatuses:
-    - imageID: docker://aaa
-- metadata:
     uid: 225f47c4-cc85-41d4-ade7-4348b233335a
     name: old-pod-0
     namespace: namespace

--- a/spec/lib/fixtures/state-multi.yml
+++ b/spec/lib/fixtures/state-multi.yml
@@ -7,8 +7,7 @@ pod:
     namespace: namespace
     labels:
       app.kubernetes.io/component: dummy
-    annotations:
-      skiff-exported-properties-dummy: '{}'
+    annotations: {}
   spec:
     subdomain: provider-role
     containers:
@@ -25,8 +24,7 @@ pod:
     namespace: namespace
     labels:
       app.kubernetes.io/component: dummy
-    annotations:
-      skiff-exported-properties-dummy: '{}'
+    annotations: {}
   spec:
     containers:
     - image: docker.io/image-one
@@ -42,8 +40,7 @@ pod:
     namespace: namespace
     labels:
       app.kubernetes.io/component: dummy
-    annotations:
-      skiff-exported-properties-dummy: '{}'
+    annotations: {}
   spec:
     subdomain: provider-role
     containers:
@@ -59,8 +56,7 @@ pod:
     namespace: namespace
     labels:
       app.kubernetes.io/component: unrelated
-    annotations:
-      skiff-exported-properties-dummy: '{}'
+    annotations: {}
   spec:
     containers:
     - image: docker://ccc
@@ -74,14 +70,50 @@ pod:
     namespace: namespace
     labels:
       app.kubernetes.io/component: pending
-    annotations:
-      skiff-exported-properties-dummy: '{}'
+    annotations: {}
   spec:
     containers:
     - image: docker://eee
   status:
     podIP: 1.2.3.4
     containerStatuses: ~ # Simulate pending pod
+
+secret:
+- metadata:
+    name: ready-pod-0-893dd4a8-2067-44d3-aae7-1389f6a1789a
+    namespace: namespace
+  data:
+    # echo '{}' | base64
+    skiff-exported-properties-dummy: "e30K"
+    # skiff-exported-digest-dummy: "ready-digest"
+- metadata:
+    name: ready-pod-too-0-fed899c8-0140-48fd-ac88-772368bde1f9
+    namespace: namespace
+  data:
+    # echo '{}' | base64
+    skiff-exported-properties-dummy: "e30K"
+    # skiff-exported-digest-dummy: "ready-digest"
+- metadata:
+    name: bootstrap-pod-3-9091e7e7-ec89-453b-b5ca-352a47772fe9
+    namespace: namespace
+  data:
+    # echo '{}' | base64
+    skiff-exported-properties-dummy: "e30K"
+    # skiff-exported-digest-dummy: "ready-digest"
+- metadata:
+    name: unrelated-pod-0-4d287101-9dba-4ae7-9447-3f3a3989badf
+    namespace: namespace
+  data:
+    # echo '{}' | base64
+    skiff-exported-properties-dummy: "e30K"
+    # skiff-exported-digest-dummy: "ready-digest"
+- metadata:
+    name: pending-pod-0-650aa4a8-2034-55c1-gge9-2451d6a2799b
+    namespace: namespace
+  data:
+    # echo '{}' | base64
+    skiff-exported-properties-dummy: "e30K"
+    # skiff-exported-digest-dummy: "ready-digest"
 
 service:
 - metadata:

--- a/spec/lib/fixtures/state.yml
+++ b/spec/lib/fixtures/state.yml
@@ -4,10 +4,10 @@ pod:
 - metadata:
     name: pod-0
     namespace: the-namespace
-    annotations:
-      skiff-exported-properties-unused: '{}'
+    annotations: {}
     labels:
       app.kubernetes.io/component: fake
+    uid: BOGUS-UID
   status:
     podIP: '192.168.2.67'
     containerStatuses:
@@ -21,10 +21,10 @@ pod:
 - metadata:
     name: other-234z234
     namespace: the-namespace
-    annotations:
-      skiff-exported-properties-provider-job: '{"hello":{"world":"ohai"}}'
+    annotations: {}
     labels:
       app.kubernetes.io/component: provider-role
+    uid: FAKE-UID
   spec:
     containers:
     - image: docker.io/image-one
@@ -34,6 +34,20 @@ pod:
     containerStatuses:
     - imageID: docker://image-one
     - imageID: docker://image-two
+
+secret:
+- metadata:
+    name: pod-0-BOGUS-UID
+    namespace: the-namespace
+  data:
+    # echo '{}' | base64
+    skiff-exported-properties-unused: "e30K"
+- metadata:
+    name: other-234z234-FAKE-UID
+    namespace: the-namespace
+  data:
+    # echo '{"hello":{"world":"ohai"}}' | base64
+    skiff-exported-properties-provider-job: "eyJoZWxsbyI6eyJ3b3JsZCI6Im9oYWkifX0K"
 
 service:
 - metadata:

--- a/spec/lib/kube_link_generator_spec.rb
+++ b/spec/lib/kube_link_generator_spec.rb
@@ -38,13 +38,11 @@ describe KubeLinkSpecs do
         client = MockKubeClient.new(fixture('state-jobless-properties.yml'))
         allow(specs).to receive(:client) { client }
         pods = specs.get_pods_for_role('dummy', 'dummy')
-        expect(pods.length).to be 3
-        expect(pods[0].metadata.name).to eq('oldest-pod-0')
-        expect(specs.get_exported_properties('dummy-role', pods[0], 'dummy')).to include('prop' => 'a')
-        expect(pods[1].metadata.name).to eq('old-pod-0')
-        expect(specs.get_exported_properties('dummy-role', pods[1], 'dummy')).to include('prop' => 'b')
-        expect(pods[2].metadata.name).to eq('new-pod-0')
-        expect(specs.get_exported_properties('dummy-role', pods[2], 'dummy')).to include('prop' => 'c')
+        expect(pods.length).to be 2
+        expect(pods[0].metadata.name).to eq('old-pod-0')
+        expect(specs.get_exported_properties('dummy-role', pods[0], 'dummy')).to include('prop' => 'b')
+        expect(pods[1].metadata.name).to eq('new-pod-0')
+        expect(specs.get_exported_properties('dummy-role', pods[1], 'dummy')).to include('prop' => 'c')
       end
 
       # Build a client with the given answers (sequentially)
@@ -83,10 +81,9 @@ describe KubeLinkSpecs do
         pods = specs.get_pods_for_role('dummy', 'dummy')
         expect(pods).not_to be_empty
         expect(answers).to be_empty
-        expect(pods.length).to eq 3
-        expect(pods[0].metadata.name).to eq('oldest-pod-0')
-        expect(pods[1].metadata.name).to eq('old-pod-0')
-        expect(pods[2].metadata.name).to eq('new-pod-0')
+        expect(pods.length).to eq 2
+        expect(pods[0].metadata.name).to eq('old-pod-0')
+        expect(pods[1].metadata.name).to eq('new-pod-0')
       end
 
       it 'should wait for all pods to be ready' do
@@ -108,10 +105,9 @@ describe KubeLinkSpecs do
         pods = specs.get_pods_for_role('dummy', 'dummy', wait_for_all: true)
         expect(pods).not_to be_empty
         expect(answers).to be_empty
-        expect(pods.length).to eq 3
-        expect(pods[0].metadata.name).to eq('oldest-pod-0')
-        expect(pods[1].metadata.name).to eq('old-pod-0')
-        expect(pods[2].metadata.name).to eq('new-pod-0')
+        expect(pods.length).to eq 2
+        expect(pods[0].metadata.name).to eq('old-pod-0')
+        expect(pods[1].metadata.name).to eq('new-pod-0')
       end
 
       it 'should accept the old pod as ready' do

--- a/spec/lib/kube_link_generator_spec.rb
+++ b/spec/lib/kube_link_generator_spec.rb
@@ -38,11 +38,13 @@ describe KubeLinkSpecs do
         client = MockKubeClient.new(fixture('state-jobless-properties.yml'))
         allow(specs).to receive(:client) { client }
         pods = specs.get_pods_for_role('dummy', 'dummy')
-        expect(pods.length).to be 2
-        expect(pods[0].metadata.name).to eq('old-pod-0')
+        expect(pods.length).to be 3
+        expect(pods[0].metadata.name).to eq('oldest-pod-0')
         expect(specs.get_exported_properties('dummy-role', pods[0], 'dummy')).to include('prop' => 'a')
-        expect(pods[1].metadata.name).to eq('new-pod-0')
+        expect(pods[1].metadata.name).to eq('old-pod-0')
         expect(specs.get_exported_properties('dummy-role', pods[1], 'dummy')).to include('prop' => 'b')
+        expect(pods[2].metadata.name).to eq('new-pod-0')
+        expect(specs.get_exported_properties('dummy-role', pods[2], 'dummy')).to include('prop' => 'c')
       end
 
       # Build a client with the given answers (sequentially)
@@ -81,9 +83,10 @@ describe KubeLinkSpecs do
         pods = specs.get_pods_for_role('dummy', 'dummy')
         expect(pods).not_to be_empty
         expect(answers).to be_empty
-        expect(pods.length).to eq 2
-        expect(pods[0].metadata.name).to eq('old-pod-0')
-        expect(pods[1].metadata.name).to eq('new-pod-0')
+        expect(pods.length).to eq 3
+        expect(pods[0].metadata.name).to eq('oldest-pod-0')
+        expect(pods[1].metadata.name).to eq('old-pod-0')
+        expect(pods[2].metadata.name).to eq('new-pod-0')
       end
 
       it 'should wait for all pods to be ready' do
@@ -105,15 +108,16 @@ describe KubeLinkSpecs do
         pods = specs.get_pods_for_role('dummy', 'dummy', wait_for_all: true)
         expect(pods).not_to be_empty
         expect(answers).to be_empty
-        expect(pods.length).to eq 2
-        expect(pods[0].metadata.name).to eq('old-pod-0')
-        expect(pods[1].metadata.name).to eq('new-pod-0')
+        expect(pods.length).to eq 3
+        expect(pods[0].metadata.name).to eq('oldest-pod-0')
+        expect(pods[1].metadata.name).to eq('old-pod-0')
+        expect(pods[2].metadata.name).to eq('new-pod-0')
       end
 
       it 'should accept the old pod as ready' do
         answers = build_answers do |_, _, pods|
           pods.map! do |pod|
-            next pod if pod.metadata.name.start_with? 'old'
+            next pod if pod.metadata.name == 'old-pod-0'
 
             # Drop the podIP
             status = OpenStruct.new(pod.status.to_h.merge(podIP: nil)).freeze

--- a/update-stemcell.sh
+++ b/update-stemcell.sh
@@ -10,13 +10,9 @@
 # - docker daemon running on the host (requires volumes)
 
 set -o errexit -o nounset
-if [ "${USER}" == "jan" ]; then
-    HELM=helm-2.11
-else
-    HELM=helm
-fi
 
-REPO="${REPO:-../scf}"
+: "${HELM:=helm}"
+: "${REPO:=../scf}"
 
 REPO="$( cd "${REPO}" && echo "${PWD}" )"
 IMAGE="$( cd "${REPO}" && source .envrc && echo "${FISSILE_STEMCELL}" )"

--- a/update-stemcell.sh
+++ b/update-stemcell.sh
@@ -10,14 +10,13 @@
 # - docker daemon running on the host (requires volumes)
 
 set -o errexit -o nounset
-
-if [ "${USER}" != "jan" ]; then
-    REPO="${REPO:-../../github.com/SUSE/scf}"
-    HELM=helm
-else
-    REPO="${REPO:-../scf}"
+if [ "${USER}" == "jan" ]; then
     HELM=helm-2.11
+else
+    HELM=helm
 fi
+
+REPO="${REPO:-../scf}"
 
 REPO="$( cd "${REPO}" && echo "${PWD}" )"
 IMAGE="$( cd "${REPO}" && source .envrc && echo "${FISSILE_STEMCELL}" )"
@@ -48,9 +47,9 @@ vagrant_ready=""
 if test -z "${NO_RUN:-}" ; then
     if ( cd "${REPO}" && (vagrant status 2>/dev/null | grep --quiet running) ) ; then
         vagrant_ready="true"
-        releases=$(${HELM} list --short)
+        releases=$("${HELM}" list --short)
         if test -n "${releases}" ; then
-            ${HELM} delete --purge ${releases}
+            "${HELM}" delete --purge ${releases}
         fi
         kubectl delete ns cf ||:
         kubectl delete ns uaa ||:


### PR DESCRIPTION
The exported secrets may contain credentials, so should not be available to everyone able to get the pod details.

This change creates a separate secret for each pod, named using both the pod `name` and `uid` (the `name` is purely for human convenience and debugging). The secret includes an owner reference back to the pod, so it will get removed whenever the pod is deleted.

The secret is only written for the main container of an instance group, but not for the `loggregator-agent` sidecar. Therefore this commit depends on an updated fissile release that sets the `KUBERNETES_CONTAINER_NAME` environment variable correspondingly: https://github.com/cloudfoundry-incubator/fissile/pull/522

jsc#CAP-761