### PR TITLE
Don't annotate pod with self-imports

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    configgin (0.19.0)
+    configgin (0.19.1)
       bosh-template (~> 2.0)
       deep_merge (~> 1.1)
       kubeclient (~> 2.0)

--- a/lib/configgin.rb
+++ b/lib/configgin.rb
@@ -115,6 +115,9 @@ class Configgin
   # patch the StatefulSets such that they will be restarted.
   def restart_affected_pods(expected_annotations)
     expected_annotations.each_pair do |instance_group_name, digests|
+      # Avoid restarting our own pod
+      next if instance_group_name == instance_group
+
       begin
         kube_client_stateful_set.patch_stateful_set(
           instance_group_name,
@@ -196,7 +199,7 @@ class Configgin
   end
 
   def instance_group
-    pod = kube_client.get_pod(@self_name, kube_namespace)
-    pod['metadata']['labels']['app.kubernetes.io/component']
+    @pod ||= kube_client.get_pod(@self_name, kube_namespace)
+    @pod['metadata']['labels']['app.kubernetes.io/component']
   end
 end

--- a/lib/configgin/version.rb
+++ b/lib/configgin/version.rb
@@ -1,3 +1,3 @@
 class Configgin
-  VERSION = '0.19.0'.freeze
+  VERSION = '0.19.1'.freeze
 end


### PR DESCRIPTION
If the job we import from is part of the same instance group, then we are already sure that we got the correct imported properties.  There is no point in adding an import annotation to our stateful set because we would just get restarted for no good reason.

[scf#CAP-150]