### PR TITLE
Fix property change detection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    configgin (0.20.0)
+    configgin (0.20.2)
       bosh-template (~> 2.0)
       deep_merge (~> 1.1)
       kubeclient (~> 4.3)

--- a/lib/configgin.rb
+++ b/lib/configgin.rb
@@ -71,7 +71,8 @@ class Configgin
   def export_job_properties(jobs)
     # Co-located containers don't get to export properties.
     return unless instance_group == ENV["KUBERNETES_CONTAINER_NAME"]
-    # Jobs (errands) don't export properties.
+    # Jobs (errands) and unowned pods (tests) don't export properties.
+    return unless self_pod['metadata']['ownerReferences']
     return unless self_pod['metadata']['ownerReferences'][0]['kind'] == "StatefulSet"
 
     sts = kube_client_stateful_set.get_stateful_set(instance_group, kube_namespace)

--- a/lib/configgin.rb
+++ b/lib/configgin.rb
@@ -106,7 +106,7 @@ class Configgin
 
     digests = {}
     jobs.each do |name, job|
-      secret.data["skiff-exported-properties-#{name}"] = Base64.encode64(job.exported_properties.to_json)
+      secret.data["skiff-exported-properties-#{name}"] = Base64.strict_encode64(job.exported_properties.to_json)
       digests[name] = property_digest(job.exported_properties)
 
       # Record initial digest values whenever the tag changes, in which case the pod startup
@@ -114,7 +114,7 @@ class Configgin
       # tags in the corresponding secrets. There is no annotation when importing this set of
       # initial values because the helm chart doesn't include any annotations, and we don't
       # want to trigger a pod restart by adding them.
-      encoded_digest = Base64.encode64(digests[name])
+      encoded_digest = Base64.strict_encode64(digests[name])
       if new_tag
         secret.data["skiff-initial-digest-#{name}"] = encoded_digest
       end

--- a/lib/configgin/version.rb
+++ b/lib/configgin/version.rb
@@ -1,3 +1,3 @@
 class Configgin
-  VERSION = '0.20.0'.freeze
+  VERSION = '0.20.2'.freeze
 end

--- a/lib/kube_link_generator.rb
+++ b/lib/kube_link_generator.rb
@@ -81,7 +81,7 @@ class KubeLinkSpecs
     # tag in the corresponding secret.
     secret = client.get_secret(role_name, namespace)
     begin
-      JSON.parse(Base64.decode64(secret.data["skiff-exported-properties-#{job_name}"]))
+      JSON.parse(Base64.strict_decode64(secret.data["skiff-exported-properties-#{job_name}"]))
     rescue
       puts "Role #{role_name} is missing skiff-exported-properties-#{job_name}"
       fail

--- a/spec/lib/configgin_spec.rb
+++ b/spec/lib/configgin_spec.rb
@@ -88,8 +88,8 @@ describe Configgin do
         subject.run
         secret = client.get_secret('instance-group', 'the-namespace')
         expect(secret).not_to be_nil
-        exported_properties = Base64.decode64(secret.data['skiff-exported-properties-loggregator_agent'])
-        initial_digest = Base64.decode64(secret.data['skiff-initial-digest-loggregator_agent'])
+        exported_properties = Base64.strict_decode64(secret.data['skiff-exported-properties-loggregator_agent'])
+        initial_digest = Base64.strict_decode64(secret.data['skiff-initial-digest-loggregator_agent'])
         expect(initial_digest).to eq property_digest(JSON.parse(exported_properties))
 
         statefulset = client.get_stateful_set('debugger', 'the-namespace')
@@ -112,7 +112,7 @@ describe Configgin do
         secret = client.get_secret('instance-group', 'the-namespace')
         expect(secret).not_to be_nil
         expect(secret.data['skiff-initial-digest-loggregator_agent']).to be_nil
-        exported_properties = Base64.decode64(secret.data['skiff-exported-properties-loggregator_agent'])
+        exported_properties = Base64.strict_decode64(secret.data['skiff-exported-properties-loggregator_agent'])
 
         statefulset = client.get_stateful_set('debugger', 'the-namespace')
         expect(statefulset).not_to be_nil


### PR DESCRIPTION
### Use "strict" Base64 encode/decode funtions to avoid newlines

The non-strict `encode64()` function inserts a newline character every 60 characters, and also appends one at the end. These newlines are not persisted in the kube secret, so subsequent comparisons with unchanged properties were erroneously indicating a value change.

### Also make sure unowned pods don't try to export properties

This applies e.g. to the bosh-tasks for running tests.

[jsc#CAP-1148]