### PR TITLE
Use versioned annotations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    configgin (0.20.2)
+    configgin (0.20.3)
       bosh-template (~> 2.0)
       deep_merge (~> 1.1)
       kubeclient (~> 4.3)

--- a/lib/configgin.rb
+++ b/lib/configgin.rb
@@ -178,7 +178,7 @@ class Configgin
       base_config = JSON.parse(File.read(job_config['base']))
       base_config.fetch('consumed_by', {}).values.each do |consumer_jobs|
         consumer_jobs.each do |consumer_job|
-          digest_key = "skiff-in-props-#{instance_group}-#{job_name}"
+          digest_key = "skiff-#{ENV['CONFIGGIN_VERSION_TAG']}-#{instance_group}-#{job_name}"
           instance_groups_to_examine[consumer_job['role']][digest_key] = job_digests[job_name]
         end
       end

--- a/lib/configgin/version.rb
+++ b/lib/configgin/version.rb
@@ -1,3 +1,3 @@
 class Configgin
-  VERSION = '0.20.2'.freeze
+  VERSION = '0.20.3'.freeze
 end

--- a/spec/lib/configgin_spec.rb
+++ b/spec/lib/configgin_spec.rb
@@ -94,7 +94,7 @@ describe Configgin do
 
         statefulset = client.get_stateful_set('debugger', 'the-namespace')
         expect(statefulset).not_to be_nil
-        expect(statefulset.spec.template.metadata.annotations['skiff-in-props-instance-group-loggregator_agent']).to be_nil
+        expect(statefulset.spec.template.metadata.annotations['skiff-1.2.3-instance-group-loggregator_agent']).to be_nil
       end
 
       it 'patches the affected statefulset' do
@@ -116,20 +116,23 @@ describe Configgin do
 
         statefulset = client.get_stateful_set('debugger', 'the-namespace')
         expect(statefulset).not_to be_nil
-        expected_digest = statefulset.spec.template.metadata.annotations['skiff-in-props-instance-group-loggregator_agent']
+        expected_digest = statefulset.spec.template.metadata.annotations['skiff-1.2.3-instance-group-loggregator_agent']
         expect(expected_digest).to eq property_digest(JSON.parse(exported_properties))
       end
     end
   end
 
   describe '#expected_annotations' do
+    before(:each) {
+      stub_const('ENV', 'CONFIGGIN_VERSION_TAG' => '1.2.3')
+    }
     let(:job_configs) { JSON.parse(File.read(fixture('nats-job-config.json'))) }
     let(:job_digests) { { 'loggregator_agent' => '123' } }
     it 'should return the correct expected annotations' do
       result = subject.expected_annotations(job_configs, job_digests)
       expect(result).to eq(
         'debugger' => {
-          'skiff-in-props-instance-group-loggregator_agent' => '123'
+          'skiff-1.2.3-instance-group-loggregator_agent' => '123'
         }
       )
     end


### PR DESCRIPTION
The helm chart doesn't know about the annotations configgin adds during runtime. During `helm upgrade` the existing stateful sets will be patched with a simple 2-way merge-patch between the old and the new charts, so any annotations configgin has applied will remain in place.

The configgin logic however relies on these annotations to be absent after initial install or after a chart version upgrade because the missing value indicates that it imports the "initial" values exported by the link provider.

This patch avoids this problem by using versioned annotation names. Unfortunately this means that old annotations will be kept around forever, but that is mostly an aesthetic issue.

[jsc#CAP-1148]